### PR TITLE
Fix eval-after-load to run after 'org feature

### DIFF
--- a/orgit-forge.el
+++ b/orgit-forge.el
@@ -59,7 +59,7 @@ These two are preserved for backward compatibly:
   :type 'string)
 
 ;;;###autoload
-(with-eval-after-load "org"
+(with-eval-after-load 'org
   (org-link-set-parameters "orgit-topic"
                            :store              #'orgit-topic-store
                            :follow             #'orgit-topic-open


### PR DESCRIPTION
Fix eval-after-load to run after 'org feature instead of a elisp file with name "org".

This fixes loading issues when users have their org-related in file that
happens to be named "org.el", see https://github.com/doomemacs/doomemacs/issues/6645.